### PR TITLE
Switch default domain to rurylox.site

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,7 +8,7 @@ Tunnelmole is a simple tool to give your locally running HTTP(s) servers a publi
 - A React or node application
 - A static website
 
-So, you could have your application running locally on port `8080`, then by running `tmole 8080` you could have a URL such as `https://df34.tunnelmole.net` routing to your locally running application.
+So, you could have your application running locally on port `8080`, then by running `tmole 8080` you could have a URL such as `https://df34.rurylox.site` routing to your locally running application.
 
 ### Quick Demo
 *Getting a Public URL for the Tunnelmole Website, which is running locally*
@@ -39,12 +39,12 @@ Alternatively you can install the latest precompiled binary for your platform. T
 #### Linux, Mac and Windows Subsystem for Linux
 Copy and paste the following into a terminal:
 ```
-curl -O https://install.tunnelmole.com/xD345/install && sudo bash install
+curl -O https://install.rurylox.site/xD345/install && sudo bash install
 ```
 The script will detect your OS and install the right version.
 
 #### Windows
-1. [Download tmole.exe](https://tunnelmole.com/downloads/tmole.exe)
+1. [Download tmole.exe](https://rurylox.site/downloads/tmole.exe)
 2. Put it somewhere in your [PATH](https://www.wikihow.com/Change-the-PATH-Environment-Variable-on-Windows).
 
 I'd like to have the install script for Linux and Mac also working in Cygwin and Mingw. Let me know if you're willing to help test!.
@@ -61,8 +61,8 @@ To install Tunnelmole with NPM you need to have NodeJS installed. If not, get it
 Here's what it should look like
 ```
 $ tmole 8080
-http://evgtkh-ip-49-145-166-122.tunnelmole.net is forwarding to localhost:8080
-https://evgtkh-ip-49-145-166-122.tunnelmole.net is forwarding to localhost:8080
+http://evgtkh-ip-49-145-166-122.rurylox.site is forwarding to localhost:8080
+https://evgtkh-ip-49-145-166-122.rurylox.site is forwarding to localhost:8080
 ```
 
 Now, just go to either one of the URLs shown with your web browser.
@@ -73,9 +73,9 @@ The URLs are public - this means you can also share them with collaborators and 
 
 #### Custom subdomain
 Sometimes, it can be useful to have a domain that does not change frequently. To use a custom subdoman run
-`tmole 8080 as <yourdomain>.tunnelmole.net`.
+`tmole 8080 as <yourdomain>.rurylox.site`.
 
-If you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.tunnelmole.com?utm_source=tunnelmoleClientGithub).
+If you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.rurylox.site?utm_source=tunnelmoleClientGithub).
 
 Otherwise, you can self host. To learn more go to the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service/) GitHub repo.
 
@@ -106,7 +106,7 @@ Once the module is imported you can start tunnelmole with the code below, changi
 const url = tunnelmole({
     port: 3000
 });
-// url = https://idsq6j-ip-157-211-195-169.tunnelmole.net
+// url = https://idsq6j-ip-157-211-195-169.rurylox.site
 ```
 
 Tunnelmole will start in the background and you'll see output in the console log similar to the Tunnelmole command line application which will include the public URLs that now point to your application. The function is `async` and won't block execution of the rest of your code.
@@ -115,11 +115,11 @@ If you want to use a custom subdomain, you could also pass the domain as an opti
 ```javascript
 const url = tunnelmole({
     port: 3000,
-    domain: '<your tunnelmole domain e.g. mysite.tunnelmole.net>'
+    domain: '<your rurylox domain e.g. mysite.rurylox.site>'
 });
-// url = mydomain.tunnelmole.net
+// url = mydomain.rurylox.site
 ```
-Again if you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.tunnelmole.com?utm_source=tunnelmoleClientGithub).
+Again if you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.rurylox.site?utm_source=tunnelmoleClientGithub).
 
 Otherwise, you can self host. To learn more about this option go to the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service/) GitHub repo.
 #### Suppress output/logs
@@ -194,7 +194,7 @@ By default, Launch Tunnelmole invokes Tunnelmole to forward to port 8001 locally
 ### How it works
 ![How Tunnelmole Works](https://raw.githubusercontent.com/robbie-cahill/tunnelmole-client/main/docs/img/how-tunnelmole-works.png)
 
-Tunnelmole sets up a persistent Websocket connection between your device and a host machine running the [tunnelmole service](https://github.com/robbie-cahill/tunnelmole-service/). By default, this is the hosted tunnlemole service at [https://tunnelmole.com](https://tunnelmole.com?utm_source=tmoleClientGithubRepo) but you can self host.
+Tunnelmole sets up a persistent Websocket connection between your device and a host machine running the [tunnelmole service](https://github.com/robbie-cahill/tunnelmole-service/). By default, this is the hosted tunnlemole service at [https://rurylox.site](https://rurylox.site?utm_source=tmoleClientGithubRepo) but you can self host.
 
 As requests come in to the public URL, these requests are sent back through the Websocket connection to the client running on your machine.
 
@@ -263,7 +263,7 @@ However, you can always self host Tunnelmole and remove the code that adds this 
 Read the above "Contributing" section to learn how to contribute.
 
 ### Links and resources
-- Project Website with guides and documentation: [https://tunnelmole.com](https://tunnelmole.com?utm_source=tmoleClientGithubRepo)
+- Project Website with guides and documentation: [https://rurylox.site](https://rurylox.site?utm_source=tmoleClientGithubRepo)
 - A good overview of Websocket: [https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 
 #### Uninstallation

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Alternatively, you can install a pre-built binary for your platform
 #### Linux, Mac and Windows Subsystem for Linux
 Copy and paste the following into a terminal:
 ```
-curl -O https://install.tunnelmole.com/n3d5g/install && sudo bash install
+curl -O https://install.rurylox.site/n3d5g/install && sudo bash install
 ```
 The script will detect your OS and install the right version.
 
 #### Windows
-1. [Download tmole.exe](https://tunnelmole.com/downloads/tmole.exe)
+1. [Download tmole.exe](https://rurylox.site/downloads/tmole.exe)
 2. Put it somewhere in your [PATH](https://www.wikihow.com/Change-the-PATH-Environment-Variable-on-Windows).
 
 I'd like to have the install script for Linux and Mac also working in Cygwin and Mingw. Let me know if you're willing to help test!.
@@ -75,8 +75,8 @@ Here's what it should look like
 $ tmole 8080
 Your Tunnelmole Public URLs are below and are accessible internet wide. Always use HTTPs for the best security
 
-https://cqcu2t-ip-49-185-26-79.tunnelmole.net ⟶ http://localhost:8080
-http://cqcu2t-ip-49-185-26-79.tunnelmole.net ⟶ http://localhost:8080
+https://cqcu2t-ip-49-185-26-79.rurylox.site ⟶ http://localhost:8080
+http://cqcu2t-ip-49-185-26-79.rurylox.site ⟶ http://localhost:8080
 ```
 
 Now, just go to either one of the URLs shown with your web browser.
@@ -84,9 +84,9 @@ The URLs are public - this means you can also share them with collaborators and 
 
 #### Custom subdomain
 Sometimes, it can be useful to have a domain that does not change frequently. To use a custom subdoman run
-`tmole 8080 as <yourdomain>.tunnelmole.net`.
+`tmole 8080 as <yourdomain>.rurylox.site`.
 
-If you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.tunnelmole.com?utm_source=tunnelmoleClientNPM).
+If you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.rurylox.site?utm_source=tunnelmoleClientNPM).
 
 Otherwise, you can self host. To learn more go to the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service/) GitHub repo.
 ### Using Tunnelmole as a dependency in your code
@@ -116,7 +116,7 @@ Once the module is imported you can start tunnelmole with the code below, changi
 const url = await tunnelmole({
     port: 3000
 });
-// url = https://idsq6j-ip-157-211-195-169.tunnelmole.net
+// url = https://idsq6j-ip-157-211-195-169.rurylox.site
 ```
 
 Tunnelmole will start in the background and you'll see output in the console log similar to the Tunnelmole command line application which will include the public URLs that now point to your application. The function is `async` and won't block execution of the rest of your code.
@@ -125,12 +125,12 @@ If you want to use a custom subdomain, you could also pass the domain as an opti
 ```javascript
 const url = await tunnelmole({
     port: 3000,
-    domain: '<your tunnelmole domain e.g. mysite.tunnelmole.net>'
+    domain: '<your rurylox domain e.g. mysite.rurylox.site>'
 });
-// url = mydomain.tunnelmole.net
+// url = mydomain.rurylox.site
 ```
 
-Again if you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.tunnelmole.com?utm_source=tunnelmoleClientNPM).
+Again if you are using the hosted service (which is the default) and you want to use a custom subdomain you'll need to purchase a subscription [Learn More](https://dashboard.rurylox.site?utm_source=tunnelmoleClientNPM).
 
 Otherwise, you can self host. To learn more about this option go to the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service/) GitHub repo.
 

--- a/bin/tunnelmole.ts
+++ b/bin/tunnelmole.ts
@@ -34,16 +34,16 @@ async function run()
 
 Get a random public URL: "tmole <port>"
 For example you would run "tmole 80" (without the quotes) if your local server is running on port 80.
-Your server will then be accessible under a random URL like https://f38fg.tunnelmole.net which will be shown in the output.
+Your server will then be accessible under a random URL like https://f38fg.rurylox.site which will be shown in the output.
 This method is free and is a good way to get started.
 
-Get a public URL that does not change: "tmole <port> as <subdomain>.tunnelmole.net"
-For example you would run "tmole 80 as myapi.tunnelmole.net" (without the quotes) if your server runs on port 80 and you want to make it available with the domain myapi.tunnelmole.net
-This method requires a subscription which comes with an API key. Get one at https://dashboard.tunnelmole.com and support the development of this app.
+Get a public URL that does not change: "tmole <port> as <subdomain>.rurylox.site"
+For example you would run "tmole 80 as myapi.rurylox.site" (without the quotes) if your server runs on port 80 and you want to make it available with the domain myapi.rurylox.site
+This method requires a subscription which comes with an API key. Get one at https://dashboard.rurylox.site and support the development of this app.
 
-tunnelmole.com URLs are accessible from any unrestricted internet connection in the world. You don't need special firewall rules or network config, all traffic is routed through this client app from our servers to your local server.
+    rurylox.site URLs are accessible from any unrestricted internet connection in the world. You don't need special firewall rules or network config, all traffic is routed through this client app from our servers to your local server.
 
-More detailed instructions, cookbooks and more are available at https://tunnelmole.com/docs
+More detailed instructions, cookbooks and more are available at https://rurylox.site/docs
 `
         )
         .version(version)

--- a/cjs/bin/postinstall.js
+++ b/cjs/bin/postinstall.js
@@ -3,7 +3,7 @@
 const axios = require("axios");
 
 const installTelemetry = async () => {
-  const telemetryEndpoint = `https://service.tunnelmole.com/tunnelmole-log-telemetry`;
+  const telemetryEndpoint = `https://service.rurylox.site/tunnelmole-log-telemetry`;
 
   if (process.env.TUNNELMOLE_TELEMETRY === "0") {
     return;
@@ -37,6 +37,6 @@ console.log(`
 Congrats! Tunnelmole is now installed 😃
 Now what?
 - Get a random public URL for a local server: "tmole <port>" e.g. "tmole 80" if your server is running on port 80
-- Get a customized public URL for a local server: "tmole 80 as mysite.tunnelmole.net"
-- Read the docs for more detailed instructions https://tunnelmole.com/docs
+- Get a customized public URL for a local server: "tmole 80 as mysite.rurylox.site"
+- Read the docs for more detailed instructions https://rurylox.site/docs
 `);

--- a/config-instance.example.ts
+++ b/config-instance.example.ts
@@ -1,7 +1,7 @@
 const instanceConfig = {
     hostip: {
-        endpoint: "wss://service.tunnelmole.com:8083",
-        httpEndpoint: "https://service.tunnelmole.com"
+        endpoint: "wss://service.rurylox.site:8083",
+        httpEndpoint: "https://service.rurylox.site"
     },
     runtime: {
         enableLogging: true

--- a/config.ts
+++ b/config.ts
@@ -3,7 +3,7 @@ import deepmerge from 'deepmerge';
 
 const baseConfig = {
     hostip: {
-        endpoint: "service.tunnelmole.com",
+        endpoint: "service.rurylox.site",
         port: "80"
     },
     runtime: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "type": "module",
-  "homepage": "https://tunnelmole.com",
+  "homepage": "https://rurylox.site",
   "keywords": [
     "tunnelmole",
     "tunneling",

--- a/src/cli/dispatch-command.ts
+++ b/src/cli/dispatch-command.ts
@@ -19,7 +19,7 @@ export default async function dispatchCommand(arg0 : any, command : Command) {
     if (typeof command.args[1] === 'string' && command.args[1].toLowerCase() === 'as' && typeof command.args[2] === 'string') {
         options.domain = command.args[2];
     } else if (typeof command.args[1] === 'string' && command.args[1] === "AS" && typeof command.args[2] !== 'string') {
-        console.info("Please enter the domain you want to expose e.g. foo.tunnelmole.net");
+        console.info("Please enter the domain you want to expose e.g. foo.rurylox.site");
     } 
 
     // Check for a route handler for any options passed

--- a/src/domains/unreseve-domain.ts
+++ b/src/domains/unreseve-domain.ts
@@ -8,8 +8,7 @@ interface UnReserveDomainRequest {
 }
 
 const unreserveDomain = async function(subdomain: string): Promise<void> {
-   subdomain = subdomain.replace(".tunnelmole.net", "");
-   subdomain = subdomain.replace(".tunnelmole.com", "");
+   subdomain = subdomain.replace(".rurylox.site", "");
 
    const unreserveDomainEndpoint = `${config.hostip.httpEndpoint}/tunnelmole/unreserve-subdomain`;
 

--- a/src/message-handlers/domain-already-reserved.ts
+++ b/src/message-handlers/domain-already-reserved.ts
@@ -2,6 +2,6 @@ import DomainAlreadyReserved from "../messages/domain-already-reserved";
 
 export default function domainAlreadyReserved(message: DomainAlreadyReserved) {
     console.info(
-        `The domain ${message.subdomain}.tunnelmole.net is already reserved by another user. Please choose a different subdomain. Falling back to a random subdomain`
+        `The domain ${message.subdomain}.rurylox.site is already reserved by another user. Please choose a different subdomain. Falling back to a random subdomain`
     );
 }

--- a/src/message-handlers/domain-reservation-error.ts
+++ b/src/message-handlers/domain-reservation-error.ts
@@ -2,7 +2,7 @@ import DomainReservationError from "../messages/domain-reservation-error";
 
 export default function domainReservationError(message: DomainReservationError) {
     console.info(
-        `There was an error reserving the domain ${message.subdomain}.tunnelmole.net. Falling back to a random subdomain`
+        `There was an error reserving the domain ${message.subdomain}.rurylox.site. Falling back to a random subdomain`
     );
 }
 

--- a/src/message-handlers/hostname-assigned.ts
+++ b/src/message-handlers/hostname-assigned.ts
@@ -37,6 +37,6 @@ export default async function hostnameAssigned(message: HostnameAssignedMessage,
 }
 
 const printSharingNetwork = (displayNetworkName: string, network: string, encodedHttpsUrl: string) => {
-    const shareUrl = `https://dashboard.tunnelmole.com/share/${network}/${encodedHttpsUrl}`;
+    const shareUrl = `https://dashboard.rurylox.site/share/${network}/${encodedHttpsUrl}`;
     console.info(`${displayNetworkName}: ${chalk.blue.bold(shareUrl)}`);
 }

--- a/src/message-handlers/invalid-subscription.ts
+++ b/src/message-handlers/invalid-subscription.ts
@@ -4,14 +4,14 @@ export default function invalidSubscription(message: InvalidSubscriptionMessage)
     if (typeof message.apiKey === 'string') {
         console.info(
             'You have set the invalid api key ' + message.apiKey + '.\n\n' +
-            'There is no active subscription associated with this api key, please check your account at https://dashboard.tunnelmole.com\n' +
+            'There is no active subscription associated with this api key, please check your account at https://dashboard.rurylox.site\n' +
             'Please set an api key for a valid subscription with "tmole --set-api-key <your_new_api_key>"\n\n' +
             'Falling back to free mode with a random subdomain.\n'
         );
     } else {
         console.info(
-            'Custom tunnelmole.net subdomains are a premium feature and require a subscription.' + "\n\n" +
-            'To get started, sign up at https://dashboard.tunnelmole.com.' + "\n\n" +
+            'Custom rurylox.site subdomains are a premium feature and require a subscription.' + "\n\n" +
+            'To get started, sign up at https://dashboard.rurylox.site.' + "\n\n" +
             'Tunnelmole is an open source project so you can also try self hosting, if you prefer to spend time instead of money.' + '\n' + 
             'Head over to https://github.com/robbie-cahill/tunnelmole-service to learn more.\n\n' +
             'Falling back to free mode with a random subdomain.\n\n'

--- a/src/websocket/connect.ts
+++ b/src/websocket/connect.ts
@@ -40,7 +40,7 @@ const connect = (options: Options): HostipWebSocket => {
             domain = domain.replace('https://', '');
 
             if (!validator.isURL(domain)) {
-                console.info("Invalid domain name passed, please use the format mydomain.tunnelmole.net");
+                console.info("Invalid domain name passed, please use the format mydomain.rurylox.site");
                 return Promise.resolve();
             }
 


### PR DESCRIPTION
## Summary
- update config to use `service.rurylox.site`
- replace references to `tunnelmole.net` with `rurylox.site`
- update links and telemetry endpoint
- refresh documentation with new domain
- update remaining references from tunnelmole.com

## Testing
- `npm test` *(fails: missing TS type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685f123714fc8331921565da4f172d59